### PR TITLE
Make private before unmount

### DIFF
--- a/internal/eosxd/node/mountutil.go
+++ b/internal/eosxd/node/mountutil.go
@@ -52,6 +52,11 @@ func slaveRecursiveBind(from, to string) error {
 	return err
 }
 
+func makeRecursivePrivateMount(mountpoint string) error {
+	_, err := exec.CombinedOutput(goexec.Command("mount", mountpoint, "--make-rprivate"))
+	return err
+}
+
 func recursiveUnmount(mountpoint string) error {
 	// We need recursive unmount because there are live mounts inside the bindmount.
 	// Unmounting only the upper autofs mount would result in EBUSY.


### PR DESCRIPTION
Nested autofs mounts (specifically /eos/squashfs) made it impossible to unmount resulting in EBUSY. Making them private
before unmount unblocks them.

Fixes https://github.com/cern-eos/eosxd-csi/issues/6