### PR TITLE
deploy(helm): configure seccomp profile for node & controller plugin

### DIFF
--- a/deployments/helm/eosxd-csi/templates/controllerplugin-deployment.yaml
+++ b/deployments/helm/eosxd-csi/templates/controllerplugin-deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         {{- include "eosxd-csi.controllerplugin.metaLabels" .  | nindent 8 }}
     spec:
+      {{- with .Values.controllerplugin.podSecurityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccount: {{ include "eosxd-csi.serviceAccountName.controllerplugin" . }}
       containers:
         - name: provisioner

--- a/deployments/helm/eosxd-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/eosxd-csi/templates/nodeplugin-daemonset.yaml
@@ -17,6 +17,9 @@ spec:
       hostPID: true
       hostNetwork: {{ .Values.nodeplugin.hostNetwork }}
       dnsPolicy: {{ .Values.nodeplugin.dnsPolicy }}
+      {{- with .Values.controllerplugin.podSecurityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: registrar
           image: {{ .Values.nodeplugin.registrar.image.repository }}:{{ .Values.nodeplugin.registrar.image.tag }}

--- a/deployments/helm/eosxd-csi/values.yaml
+++ b/deployments/helm/eosxd-csi/values.yaml
@@ -159,19 +159,19 @@ nodeplugin:
 
   # Extra volumes to be appended to nodeplugin's Pod.spec.volumes.
   extraVolumes:
-  - name: host-var-cache
-    hostPath:
-      path: /var/cache
-  - name: etc-eos
-    configMap:
-      name: eos-csi-dir-etc-eos
-  - name: etc-auto-master-d
-    configMap:
-      name: eos-csi-dir-etc-auto-master-d
-  - name: etc-eos-keytab
-    secret:
-      secretName: eos-csi-file-etc-eos-keytab
-      defaultMode: 0400
+    - name: host-var-cache
+      hostPath:
+        path: /var/cache
+    - name: etc-eos
+      configMap:
+        name: eos-csi-dir-etc-eos
+    - name: etc-auto-master-d
+      configMap:
+        name: eos-csi-dir-etc-auto-master-d
+    - name: etc-eos-keytab
+      secret:
+        secretName: eos-csi-file-etc-eos-keytab
+        defaultMode: 0400
 
   # eosxd CSI image and container resources specs.
   plugin:
@@ -194,15 +194,15 @@ nodeplugin:
     # Extra volume mounts to append to nodeplugin's
     # Pod.spec.containers[name="automount"].volumeMounts.
     extraVolumeMounts:
-    - name: host-var-cache
-      mountPath: /var/cache
-    - name: etc-eos
-      mountPath: /etc/eos
-    - name: etc-auto-master-d
-      mountPath: /etc/auto.master.d
-    - name: etc-eos-keytab
-      mountPath: /etc/eos.keytab
-      subPath: eos.keytab
+      - name: host-var-cache
+        mountPath: /var/cache
+      - name: etc-eos
+        mountPath: /etc/eos
+      - name: etc-auto-master-d
+        mountPath: /etc/auto.master.d
+      - name: etc-eos-keytab
+        mountPath: /etc/eos.keytab
+        subPath: eos.keytab
 
   mountreconciler:
     image:
@@ -229,6 +229,11 @@ nodeplugin:
     # all Pods that mount eosxd volumes on that node must be restarted (deleted)
     # too in order to refresh the mounts.
     type: OnDelete
+
+  # Pod-level security context for nodeplugin daemonset.
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
 
   # Pod priority class name.
   priorityClassName: system-node-critical
@@ -288,6 +293,11 @@ controllerplugin:
   # Deployment update strategy.
   deploymentStrategySpec:
     type: RollingUpdate
+
+  # Pod-level security context for controllerplugin deployment.
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
 
   # Pod priority class name.
   priorityClassName: ""

--- a/example/volume-pv-pvc.yaml
+++ b/example/volume-pv-pvc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  # PV name contains namespace name of its target PVC so that we can distiguish it easier.
+  # PV name contains namespace name of its target PVC so that we can distinguish it easier.
   name: eos-default
 spec:
   csi:


### PR DESCRIPTION
* deploy(helm): configured a seccomp profile of `RuntimeDefault` for nodeplugin daemonset and controllerplugin deployment.
* chore: formatted helm values file with `yamlfmt` for readability.