### PR TITLE
deploy: set plugin image tags from Chart AppVersion

### DIFF
--- a/deployments/helm/eosxd-csi/Chart.yaml
+++ b/deployments/helm/eosxd-csi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "latest"
+appVersion: "v1.4.0"
 description: A Helm chart to deploy the eosxd-CSI Plugin
 name: eosxd-csi
-version: "1.0.0"
+version: 1.4.0

--- a/deployments/helm/eosxd-csi/templates/controllerplugin-deployment.yaml
+++ b/deployments/helm/eosxd-csi/templates/controllerplugin-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccount: {{ include "eosxd-csi.serviceAccountName.controllerplugin" . }}
       containers:
         - name: provisioner
-          image: {{ .Values.controllerplugin.provisioner.image.repository }}:{{ .Values.controllerplugin.provisioner.image.tag }}
+          image: {{ .Values.controllerplugin.provisioner.image.repository }}:{{ .Values.controllerplugin.provisioner.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.controllerplugin.provisioner.image.pullPolicy }}
           args:
             - -v={{ .Values.logVerbosityLevel }}
@@ -37,7 +37,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: controllerplugin
-          image: {{ .Values.controllerplugin.plugin.image.repository }}:{{ .Values.controllerplugin.plugin.image.tag }}
+          image: {{ .Values.controllerplugin.plugin.image.repository }}:{{ .Values.controllerplugin.plugin.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.controllerplugin.plugin.image.pullPolicy }}
           command: [/csi-driver]
           args:

--- a/deployments/helm/eosxd-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/eosxd-csi/templates/nodeplugin-daemonset.yaml
@@ -45,7 +45,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: nodeplugin
-          image: {{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}
+          image: {{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag | default .Chart.AppVersion }}
           command: [/csi-driver]
           args:
             - -v={{ .Values.logVerbosityLevel }}
@@ -92,7 +92,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: automount
-          image: {{ .Values.nodeplugin.automount.image.repository }}:{{ .Values.nodeplugin.automount.image.tag }}
+          image: {{ .Values.nodeplugin.automount.image.repository }}:{{ .Values.nodeplugin.automount.image.tag | default .Chart.AppVersion }}
           command: [/automount-runner]
           args:
             - -v={{ .Values.logVerbosityLevel }}
@@ -121,7 +121,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: mountreconciler
-          image: {{ .Values.nodeplugin.mountreconciler.image.repository }}:{{ .Values.nodeplugin.mountreconciler.image.tag }}
+          image: {{ .Values.nodeplugin.mountreconciler.image.repository }}:{{ .Values.nodeplugin.mountreconciler.image.tag | default .Chart.AppVersion }}
           command: [/mount-reconciler]
           args:
             - -v={{ .Values.logVerbosityLevel }}

--- a/deployments/helm/eosxd-csi/values.yaml
+++ b/deployments/helm/eosxd-csi/values.yaml
@@ -152,7 +152,6 @@ extraConfigMaps:
 # Node plugin handles node-local operations, e.g. mounting and unmounting
 # eosxd repositories.
 nodeplugin:
-
   # Component name. Used as `component` label value
   # and to generate DaemonSet name.
   name: nodeplugin
@@ -177,7 +176,7 @@ nodeplugin:
   plugin:
     image:
       repository: registry.cern.ch/kubernetes/eosxd-csi
-      tag: v1.1.1
+      tag: "" # If no tag specified default to Chart AppVersion.
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -188,7 +187,7 @@ nodeplugin:
   automount:
     image:
       repository: registry.cern.ch/kubernetes/eosxd-csi
-      tag: v1.1.1
+      tag: "" # If no tag specified default to Chart AppVersion.
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -207,7 +206,7 @@ nodeplugin:
   mountreconciler:
     image:
       repository: registry.cern.ch/kubernetes/eosxd-csi
-      tag: v1.1.1
+      tag: "" # If no tag specified default to Chart AppVersion.
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -218,7 +217,7 @@ nodeplugin:
   registrar:
     image:
       repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-      tag: v2.5.1
+      tag: v2.11.0
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -263,7 +262,6 @@ nodeplugin:
 # of a reference to eosxd repositories used inside the CO (e.g. Kubernetes), and are not modifying
 # the eosxd store in any way.
 controllerplugin:
-
   # Component name. Used as `component` label value
   # and to generate DaemonSet name.
   name: controllerplugin
@@ -277,7 +275,7 @@ controllerplugin:
   plugin:
     image:
       repository: registry.cern.ch/kubernetes/eosxd-csi
-      tag: v1.1.1
+      tag: "" # If no tag specified default to Chart AppVersion.
       pullPolicy: IfNotPresent
     resources: {}
     extraVolumeMounts: []
@@ -286,7 +284,7 @@ controllerplugin:
   provisioner:
     image:
       repository: k8s.gcr.io/sig-storage/csi-provisioner
-      tag: v3.2.1
+      tag: v5.0.1
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -313,7 +311,6 @@ controllerplugin:
 
   # ServiceAccount to use with Controller plugin Deployment.
   serviceAccount:
-
     # Name of the ServiceAccount (to use and/or create).
     # If no name is provided, Helm chart will generate one.
     serviceAccountName: ""
@@ -324,7 +321,6 @@ controllerplugin:
 
   # RBAC rules assigned to the ServiceAccount defined above.
   rbac:
-
     # Whether to create RBACs in the eosxd CSI namespace.
     # If not, it is expected they are already present.
     create: true

--- a/deployments/helm/eosxd-csi/values.yaml
+++ b/deployments/helm/eosxd-csi/values.yaml
@@ -217,7 +217,7 @@ nodeplugin:
   registrar:
     image:
       repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-      tag: v2.11.0
+      tag: v2.10.1
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -284,7 +284,7 @@ controllerplugin:
   provisioner:
     image:
       repository: k8s.gcr.io/sig-storage/csi-provisioner
-      tag: v5.0.1
+      tag: v4.0.1
       pullPolicy: IfNotPresent
     resources: {}
 


### PR DESCRIPTION
Aims to simplify the release process as tags only need to be updated in `Chart.yaml` file, as if no image tag for plugins are specified it will default to Chart AppVersion. 

Tags can still be optionally set in the `values.yaml`.