### PR TITLE
deploy: /etc/krb5.conf.d/crypto-policies configurable via helm rather than being baked into dockerfile

### DIFF
--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -46,10 +46,6 @@ LABEL description="EOSxd CSI Plugin" \
       org.opencontainers.image.base.digest="" \
       org.opencontainers.image.base.name=""
 
-# Override the default list of accepted KRB ciphers by adding "arcfour-hmac-md5"
-# to retain support for tickets created by cc7 clients.
-COPY deployments/docker/crypto-policies /etc/krb5.conf.d/crypto-policies
-
 COPY bin/linux-${TARGETARCH}/csi-driver /csi-driver
 COPY bin/linux-${TARGETARCH}/automount-runner /automount-runner
 COPY bin/linux-${TARGETARCH}/mount-reconciler /mount-reconciler

--- a/deployments/docker/crypto-policies
+++ b/deployments/docker/crypto-policies
@@ -1,6 +1,0 @@
-# Added by EOSxd CSI driver.
-# Overrides the default list of accepted KRB ciphers by adding "arcfour-hmac-md5"
-# to retain support for tickets created by cc7 clients.
-
-[libdefaults]
-permitted_enctypes = arcfour-hmac-md5 aes256-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128 aes128-cts-hmac-sha1-96

--- a/deployments/helm/eosxd-csi/values.yaml
+++ b/deployments/helm/eosxd-csi/values.yaml
@@ -12,6 +12,9 @@ extraSecrets:
 # ConfigMap data supports go-template expressions.
 extraConfigMaps:
   # /etc/krb5.conf.d/crypto-policies
+  #
+  # Required to override the default list of accepted KRB ciphers by adding
+  # "arcfour-hmac-md5" to retain support for tickets created by cc7 clients.
   eos-csi-dir-etc-krb5-conf:
     crypto-policies: |
       # Added by EOSxd CSI driver.

--- a/deployments/helm/eosxd-csi/values.yaml
+++ b/deployments/helm/eosxd-csi/values.yaml
@@ -11,6 +11,16 @@ extraSecrets:
 # These can be used e.g. when defining eosxd client configuration.
 # ConfigMap data supports go-template expressions.
 extraConfigMaps:
+  # /etc/krb5.conf.d/crypto-policies
+  eos-csi-dir-etc-krb5-conf:
+    crypto-policies: |
+      # Added by EOSxd CSI driver.
+      # Overrides the default list of accepted KRB ciphers by adding "arcfour-hmac-md5"
+      # to retain support for tickets created by cc7 clients.
+
+      [libdefaults]
+      permitted_enctypes = arcfour-hmac-md5 aes256-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128 aes128-cts-hmac-sha1-96
+
   eos-csi-dir-etc-auto-master-d:
     # /etc/auto.master.d/eos.autofs
     eos.autofs: |
@@ -152,7 +162,6 @@ extraConfigMaps:
 # Node plugin handles node-local operations, e.g. mounting and unmounting
 # eosxd repositories.
 nodeplugin:
-
   # Component name. Used as `component` label value
   # and to generate DaemonSet name.
   name: nodeplugin
@@ -172,6 +181,9 @@ nodeplugin:
       secret:
         secretName: eos-csi-file-etc-eos-keytab
         defaultMode: 0400
+    - name: eos-csi-dir-etc-krb5-conf
+      configMap:
+        name: eos-csi-dir-etc-krb5-conf
 
   # eosxd CSI image and container resources specs.
   plugin:
@@ -182,7 +194,9 @@ nodeplugin:
     resources: {}
     # Extra volume mounts to append to nodeplugin's
     # Pod.spec.containers[name="nodeplugin"].volumeMounts.
-    extraVolumeMounts: []
+    extraVolumeMounts:
+      - name: etc-eos-crypto-policies
+        mountPath: /etc/krb5.conf.d/crypto-policies
 
   # eosxd CSI image and container resources specs.
   automount:
@@ -203,6 +217,8 @@ nodeplugin:
       - name: etc-eos-keytab
         mountPath: /etc/eos.keytab
         subPath: eos.keytab
+      - name: eos-csi-dir-etc-krb5-conf
+        mountPath: /etc/krb5.conf.d
 
   mountreconciler:
     image:
@@ -212,7 +228,9 @@ nodeplugin:
     resources: {}
     # Extra volume mounts to append to nodeplugin's
     # Pod.spec.containers[name="mountreconciler"].volumeMounts.
-    extraVolumeMounts: []
+    extraVolumeMounts:
+      - name: eos-csi-dir-etc-krb5-conf
+        mountPath: /etc/krb5.conf.d
 
   # csi-node-driver-registrar image and container resources specs.
   registrar:
@@ -259,11 +277,10 @@ nodeplugin:
   dnsPolicy: ClusterFirstWithHostNet
 
 # CSI Controller plugin Deployment configuration.
-# eosxd CSI supports volume provisioning, however the provisioned volumes only fulfill the role
+# eosxd CSI supports volume provisioning, however the provisioned volumes only fulfil the role
 # of a reference to eosxd repositories used inside the CO (e.g. Kubernetes), and are not modifying
 # the eosxd store in any way.
 controllerplugin:
-
   # Component name. Used as `component` label value
   # and to generate DaemonSet name.
   name: controllerplugin
@@ -271,7 +288,10 @@ controllerplugin:
   # Number of Deployment replicas. In general, one is sufficient.
   replicas: 1
 
-  extraVolumes: []
+  extraVolumes:
+    - name: eos-csi-dir-etc-krb5-conf
+      configMap:
+        name: eos-csi-dir-etc-krb5-conf
 
   # eosxd CSI image and container resources specs.
   plugin:
@@ -280,7 +300,9 @@ controllerplugin:
       tag: v1.1.1
       pullPolicy: IfNotPresent
     resources: {}
-    extraVolumeMounts: []
+    extraVolumeMounts:
+      - name: eos-csi-dir-etc-krb5-conf
+        mountPath: /etc/krb5.conf.d
 
   # CSI external-provisioner image and container resources specs.
   provisioner:
@@ -313,7 +335,6 @@ controllerplugin:
 
   # ServiceAccount to use with Controller plugin Deployment.
   serviceAccount:
-
     # Name of the ServiceAccount (to use and/or create).
     # If no name is provided, Helm chart will generate one.
     serviceAccountName: ""
@@ -324,7 +345,6 @@ controllerplugin:
 
   # RBAC rules assigned to the ServiceAccount defined above.
   rbac:
-
     # Whether to create RBACs in the eosxd CSI namespace.
     # If not, it is expected they are already present.
     create: true

--- a/deployments/helm/eosxd-csi/values.yaml
+++ b/deployments/helm/eosxd-csi/values.yaml
@@ -195,8 +195,8 @@ nodeplugin:
     # Extra volume mounts to append to nodeplugin's
     # Pod.spec.containers[name="nodeplugin"].volumeMounts.
     extraVolumeMounts:
-      - name: etc-eos-crypto-policies
-        mountPath: /etc/krb5.conf.d/crypto-policies
+      - name: eos-csi-dir-etc-krb5-conf
+        mountPath: /etc/krb5.conf.d
 
   # eosxd CSI image and container resources specs.
   automount:


### PR DESCRIPTION
Required to have configurable crypto policies to support upcoming EOS migrations to Alma9.