### PR TITLE
fix: remove deprecated arcfour-hmac-md5 cipher

### DIFF
--- a/deployments/helm/eosxd-csi/values.yaml
+++ b/deployments/helm/eosxd-csi/values.yaml
@@ -22,7 +22,7 @@ extraConfigMaps:
       # to retain support for tickets created by cc7 clients.
 
       [libdefaults]
-      permitted_enctypes = arcfour-hmac-md5 aes256-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128 aes128-cts-hmac-sha1-96
+      permitted_enctypes = aes256-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128 aes128-cts-hmac-sha1-96
 
   eos-csi-dir-etc-auto-master-d:
     # /etc/auto.master.d/eos.autofs


### PR DESCRIPTION
The `arcfour-hmac-md5` cipher is deprecated in alma9. Ongoing migrations at cern from cc7 -> alma9 mean that as clients are upgraded eos-csi-drivers using the old cipher will no longer work.

This PR removes the deprecated cipher and should be accompanied by a patch release in cern-magnum that we can use to advertise the fix / changing functionality.