### PR TITLE
deploy(helm): eosxd-csi nodeplugin daemonsets update strategy is now `RollingUpdate`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,8 +48,20 @@ build-chart:
     variables:
       PUSH_CHART: "true"
   - if: $CI_COMMIT_BRANCH
+  image: registry.cern.ch/kubernetes/ops:0.4.0
   stage: build-chart
-  extends: .deploy_helm
+  script: |
+    CHART_NAME=eosxd-csi
+    helm package "deployments/helm/${CHART_NAME}"
+
+    if $PUSH_CHART; then
+      helm registry login registry.cern.ch -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD
+      helm push ${CHART_NAME}-${CI_COMMIT_TAG}.tgz "oci://${REGISTRY_CHART_PATH}"
+
+      echo -n "${HARBOR_SIGNKEY}" | base64 -d > .sign.key
+      cosign login registry.cern.ch -u ${HARBOR_USER} -p ${HARBOR_TOKEN}
+      cosign sign --key .sign.key -y "${REGISTRY_CHART_PATH}/${CHART_NAME}:${CI_COMMIT_TAG}"
+    fi
   variables:
     REGISTRY_CHART_PATH: registry.cern.ch/kubernetes/charts
-    COSIGN_PRIVATE_KEY: "${HARBOR_SIGNKEY}"
+    COSIGN_PRIVATE_KEY: "$HARBOR_SIGNKEY"

--- a/deployments/helm/eosxd-csi/templates/controllerplugin-deployment.yaml
+++ b/deployments/helm/eosxd-csi/templates/controllerplugin-deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         {{- include "eosxd-csi.controllerplugin.metaLabels" .  | nindent 8 }}
+      annotations:
+        checksum/config: {{ .Values.extraConfigMaps | toJson | sha256sum }}
     spec:
       {{- with .Values.controllerplugin.podSecurityContext }}
       securityContext: {{ toYaml . | nindent 8 }}

--- a/deployments/helm/eosxd-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/eosxd-csi/templates/nodeplugin-daemonset.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         {{- include "eosxd-csi.nodeplugin.metaLabels" .  | nindent 8 }}
+      annotations:
+        checksum/config: {{ .Values.extraConfigMaps | toJson | sha256sum }}
     spec:
       hostPID: true
       hostNetwork: {{ .Values.nodeplugin.hostNetwork }}

--- a/deployments/helm/eosxd-csi/values.yaml
+++ b/deployments/helm/eosxd-csi/values.yaml
@@ -12,15 +12,12 @@ extraSecrets:
 # ConfigMap data supports go-template expressions.
 extraConfigMaps:
   # /etc/krb5.conf.d/crypto-policies
-  #
-  # Required to override the default list of accepted KRB ciphers by adding
-  # "arcfour-hmac-md5" to retain support for tickets created by cc7 clients.
   eos-csi-dir-etc-krb5-conf:
     crypto-policies: |
       # Added by EOSxd CSI driver.
-      # Overrides the default list of accepted KRB ciphers by adding "arcfour-hmac-md5"
-      # to retain support for tickets created by cc7 clients.
-
+      # This was initially added to add support for the "arcfour-hmac-md5" KRB
+      # cipher, however this cipher has now been deprecated as of 11/09/2024 at
+      # CERN.
       [libdefaults]
       permitted_enctypes = aes256-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128 aes128-cts-hmac-sha1-96
 
@@ -245,11 +242,10 @@ nodeplugin:
 
   # DaemonSet update strategy.
   updateStrategySpec:
-    # When eosxd Node plugin Pod is restarted, all existing eosxd mounts on
-    # that node will break. If the Node plugin DaemonSet needs to be updated,
-    # all Pods that mount eosxd volumes on that node must be restarted (deleted)
-    # too in order to refresh the mounts.
-    type: OnDelete
+    # Prior versions of eosxd-csi had issues whereby restarting the nodeplugin
+    # broke existing mounts (hence this was set to OnDelete). However the use of
+    # the automount reconciliation sidecar allows for stale / broken mounts to be
+    type: RollingUpdate
 
   # Pod-level security context for nodeplugin daemonset.
   podSecurityContext:


### PR DESCRIPTION
* eosxd-csi nodeplugin daemonsets update strategy is now `RollingUpdate`. This will ensure daemonsets pods are now updated after `helm upgrade ...`.
* added checksum annotation of `extraConfigMaps` to `controllerplugin` and `nodeplugin`, which will ensure that config only updates are propagated to pods.
* updated gitlab build-chart ci to fixing cosigning of helm charts in `registry.cern.ch`.

closes: 
* https://gitlab.cern.ch/kubernetes/storage/eosxd-csi/-/issues/34
* https://gitlab.cern.ch/kubernetes/storage/eosxd-csi/-/issues/33