### PR TITLE
deploy(helm): fix nodeplugin security context referencing controllerplugin config

### DIFF
--- a/deployments/helm/eosxd-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/eosxd-csi/templates/nodeplugin-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
       hostPID: true
       hostNetwork: {{ .Values.nodeplugin.hostNetwork }}
       dnsPolicy: {{ .Values.nodeplugin.dnsPolicy }}
-      {{- with .Values.controllerplugin.podSecurityContext }}
+      {{- with .Values.nodeplugin.podSecurityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
       containers:


### PR DESCRIPTION
`nodeplugin` security context was incorrectly pulling from the `controllerplugin` config, this PR corrects the typo in the `nodeplugin` daemonset template.