### PR TITLE
Update Dockerfile to newer EOS version (5.3.19)

### DIFF
--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf install -y \
         autofs \
         cern-eos-autofs \
         cern-eos-autofs-squashfs \
-        eos-fusex-5.3.14 && \
+        eos-fusex-5.3.19 && \
 	dnf clean all && \
     rm -rf \
         /etc/auto.eos.main.misc    \


### PR DESCRIPTION
Hi, this is to update the eosxd fuse component to the version which was recently tagged into stable (i.e. for batch & lxplus). ( https://its.cern.ch/jira/browse/CRM-5102 )

Thank you.