### PR TITLE
build(ci): migrate docker build away from privileged runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,16 @@
 include:
-- project: 'ci-tools/container-image-ci-templates'
-  file: 'docker-image.gitlab-ci.yml'
-  ref: master
-- project: 'ci-tools/container-image-ci-templates'
-  file: 'helm.gitlab-ci.yml'
+- project: kubernetes/tools/gitlab-ci
+  file:
+  - buildkit.gitlab-ci.yml
   ref: master
 
 stages:
-- build-bin
-- build-image
-- build-chart
+  - setup
+  - build
+  - deploy
 
-build-bin:
-  stage: build-bin
+build::bin:
+  stage: setup
   rules:
   - if: $CI_COMMIT_BRANCH || $CI_COMMIT_TAG
   image: registry.cern.ch/docker.io/library/golang:1.24
@@ -23,35 +21,36 @@ build-bin:
   script:
   - make build-cross
 
-build-image:
+build::image:
   rules:
   - if: $CI_COMMIT_TAG
     variables:
       PUSH_IMAGE: "true"
-      IMAGE_TAG: $CI_COMMIT_TAG
+      IMAGE_TAGS: $CI_COMMIT_TAG
   - if: $CI_COMMIT_BRANCH
     variables:
-      IMAGE_TAG: $CI_COMMIT_BRANCH
-  stage: build-image
-  extends: .build_docker
+      IMAGE_TAGS: $CI_COMMIT_SHA
+      PUSH_IMAGE: "false"
   variables:
-    REGISTRY_IMAGE_PATH: "registry.cern.ch/kubernetes/eosxd-csi:$IMAGE_TAG"
-    COSIGN_PRIVATE_KEY: "${HARBOR_SIGNKEY}"
+    BUILDKIT_ADDITIONAL_ARGS: "--opt build-arg:RELEASE=$IMAGE_TASG --opt build-arg:GITREF=$CI_COMMIT_SHA --opt build-arg:CREATED=$CI_PIPELINE_CREATED_AT"
+    CI_REGISTRY: registry.cern.ch
     CONTEXT_DIR: "."
-    DOCKER_FILE_NAME: "deployments/docker/Dockerfile"
+    DOCKERFILE: "deployments/docker/Dockerfile"
+    IMAGE: "registry.cern.ch/kubernetes/eosxd-csi"
     PLATFORMS: "linux/amd64,linux/arm64"
-    BUILD_ARGS: "RELEASE=$IMAGE_TAG GITREF=$CI_COMMIT_SHA CREATED=$CI_PIPELINE_CREATED_AT"
+    USE_CACHE: "false"
 
-build-chart:
+package::chart:
+  stage: deploy
   rules:
   - if: $CI_COMMIT_TAG
     variables:
       PUSH_CHART: "true"
   - if: $CI_COMMIT_BRANCH
+    variables:
+      PUSH_CHART: "false"
   image: registry.cern.ch/kubernetes/ops:0.6.0
-  stage: build-chart
   script: |
-    CHART_NAME=eosxd-csi
     helm package "deployments/helm/${CHART_NAME}"
 
     if $PUSH_CHART; then
@@ -65,3 +64,4 @@ build-chart:
   variables:
     REGISTRY_CHART_PATH: registry.cern.ch/kubernetes/charts
     COSIGN_PRIVATE_KEY: "$HARBOR_SIGNKEY"
+    CHART_NAME: eosxd-csi


### PR DESCRIPTION
Migrates builds away from using privileged gitlab runners and instead rely on buildkit templates.

This is to standardise the build processes across the kubernetes service, but has the benefit of being faster as it does not require waiting for a vm to be spun up with dind for every build.