### PR TITLE
fix: drop setting KEYRING for kerberos authentication

### DIFF
--- a/.github/workflows/ci-test-go.yaml
+++ b/.github/workflows/ci-test-go.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Verify gofumpt has been run
         run: |
           set -e
-          go install mvdan.cc/gofumpt@latest
+          go install mvdan.cc/gofumpt@v0.9.2
           gofumpt -l -w .
           if [ ! -z "$(git status --porcelain .)" ]; then
               >&2 echo "Running gofumpt modified source code"

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM gitlab-registry.cern.ch/linuxsupport/alma9-base:20250730-2
 
+# Do not use KEYRING for kerberos authentication
+RUN sed -i '/default_ccache_name.*KEYRING/d' /etc/krb5.conf
+
 # Setup EOS repository.
 COPY deployments/docker/eos9al-stable.repo /etc/yum.repos.d/eos9al-stable.repo
 


### PR DESCRIPTION
Remove KEYRING configuration in /etc/krb5.conf. This currently breaks kerberos authentication by default requiring users to manually set KRB5CCNAME to authenticate with kerberos.