### PR TITLE
build: upgrade eosxd-fusex to 5.4.9

### DIFF
--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN dnf install -y \
         autofs \
         cern-eos-autofs \
         cern-eos-autofs-squashfs \
-        eos-fusex-5.4.8 && \
+        eos-fusex-5.4.9 && \
 	dnf clean all && \
     rm -rf \
         /etc/auto.eos.main.misc    \


### PR DESCRIPTION
Hello,

Tracking the version in koji stable (i.e. as used for plus+batch). Please could it be included in the next eosxd-csi release?

Thank you.